### PR TITLE
Fix hit-testing and pointer position calculation.

### DIFF
--- a/src/glview/Camera.cc
+++ b/src/glview/Camera.cc
@@ -88,7 +88,7 @@ void Camera::scaleDistance(double scale)
 	this->viewer_distance *= scale;
 }
 
-Camera::ProjectionType Camera::GetProjection() const
+Camera::ProjectionType Camera::getProjection() const
 {
 	return this->projection;
 }

--- a/src/glview/Camera.h
+++ b/src/glview/Camera.h
@@ -57,7 +57,7 @@ public:
 	// Perspective settings
 	double fov; // Field of view
 
-	ProjectionType GetProjection() const;
+	ProjectionType getProjection() const;
 	void setFrustum(Camera::Frustum const &);
 
 	Eigen::Vector3d hitLookAt_;

--- a/src/platform/OpenGlUtils.h
+++ b/src/platform/OpenGlUtils.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <Eigen/Dense>
 #include "Camera.h"
+#include "QGLView.h"
 #include "renderer.h"
 
 Renderer::shaderinfo_t CreateShaderInfo(const std::string& shaderVertexfile, const std::string& shaderFragfile);
@@ -10,10 +11,10 @@ Renderer::shaderinfo_t CreateShaderInfo(const std::string& shaderVertexfile, con
  * position
  * direction
  * diameter
- * frustrum  
+ * frustrum
  * */
 double GetZBufferDepth(Eigen::Vector3d const &position, Eigen::Vector3d const &direction,
-											 double diameter, Camera const& cam, std::function<void(const Renderer::shaderinfo_t *)> prepareDrawer, 
+											 double diameter, Camera const& cam, std::function<void(const Renderer::shaderinfo_t *)> prepareDrawer,
 											 std::function<void(const Renderer::shaderinfo_t *)> drawer);
 
-Eigen::Vector3d GetCursorWorldCoordinates(Camera const &cam, Eigen::Vector2d const&mousePos);
+Eigen::Vector3d GetCursorWorldCoordinates(QGLView *view, Eigen::Vector2d const& mousePos);


### PR DESCRIPTION
Changed the interface naming to camel case for getProjection. Fix the accesssors/mutator for ViewExtents and Frustum. Ensure that the correct opengl context is being used for the hit-testing and pointer position calculation.
Fix the mouse position to world coordinate conversion.